### PR TITLE
mqe-56 use MSH-4

### DIFF
--- a/src/main/java/org/immregistries/dqa/hl7util/parser/HL7QuickParser.java
+++ b/src/main/java/org/immregistries/dqa/hl7util/parser/HL7QuickParser.java
@@ -6,18 +6,26 @@ import java.util.regex.Pattern;
 public enum HL7QuickParser {
   INSTANCE;
   private final String msh7Regex = "^MSH(?:\\|[^|]*?){6}([^|]+)\\|";
+  private final String msh4Regex = "^MSH(?:\\|[^|]*?){3}([^|]+)\\|";
   private Pattern msh7 = Pattern.compile(msh7Regex);
+  private Pattern msh4 = Pattern.compile(msh4Regex);
   private static final String MSH_REGEX = "^\\s*MSH\\|\\^~\\\\&\\|.*";
   private static final String FHS_BHS_REGEX = "^\\s*(FHS|BHS)\\|.*";
   private static final String HL7_SEGMENT_REGEX = "^\\w\\w\\w\\|.*";
 
   public String getMsh7MessageDate(String message) {
-    Matcher matcher = msh7.matcher(message);
+    return getFirstMatch(msh7, message);
+  }
+
+  public String getMsh4Sender(String message) {
+    return getFirstMatch(msh4, message);
+  }
+
+  String getFirstMatch(Pattern p, String message) {
+    Matcher matcher = p.matcher(message);
     if (matcher.find()) {
-      String msgDate = matcher.group(1);
-      return msgDate;
+      return matcher.group(1);
     }
     return "";
   }
-
 }

--- a/src/test/java/org/immregistries/dqa/hl7util/parser/HL7QuickParserTest.java
+++ b/src/test/java/org/immregistries/dqa/hl7util/parser/HL7QuickParserTest.java
@@ -15,4 +15,10 @@ public class HL7QuickParserTest {
 		String date = quick.getMsh7MessageDate(MSH);
 		assertEquals("Should match and find", "20140619191115", date);
 	}
+
+	@Test
+	public void testMSH4() {
+		String date = quick.getMsh4Sender(MSH);
+		assertEquals("Should match and find", "1337-44-01", date);
+	}
 }


### PR DESCRIPTION
This is a bugfix to use MSH-4 as the facility for messages coming into the system through the file input